### PR TITLE
Add feed browsing and episode status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ PodInsights is a simple command-line tool that helps you transcribe podcast audi
 - [`faster-whisper`](https://github.com/guillaumekln/faster-whisper) installed for audio transcription
 - [`openai`](https://pypi.org/project/openai/) and a valid `OPENAI_API_KEY` environment variable
 - Optional for the web interface: [`Flask`](https://palletsprojects.com/p/flask/), [`feedparser`](https://pypi.org/project/feedparser/), and [`requests`](https://pypi.org/project/requests/)
+  (`sqlite3` from the standard library is used for episode tracking)
 
 ## Usage (CLI)
 
@@ -35,5 +36,7 @@ pip install flask feedparser requests
 python podinsights_web.py
 ```
 
-Navigate to `http://localhost:5000` and provide an RSS feed URL. You can then select an episode to download and analyze using the same logic as the CLI tool.
+Navigate to `http://localhost:5000` and add an RSS feed URL. Stored feeds are listed on the home page so you can return to them later. Selecting a feed shows the episodes along with their processing status.
+
+Processed episodes are stored in a local SQLite database (`episodes.db`). Each episode records the transcript, summary, and action items. The feed view reports whether these pieces of information have been extracted.
 

--- a/database.py
+++ b/database.py
@@ -1,0 +1,114 @@
+"""Simple SQLite helpers for PodInsights."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable, Optional, List
+
+DB_PATH = "episodes.db"
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Initialize the database if it does not exist."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS feeds (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT UNIQUE,
+                title TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS episodes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                feed_id INTEGER,
+                url TEXT UNIQUE,
+                title TEXT,
+                transcript TEXT,
+                summary TEXT,
+                action_items TEXT,
+                FOREIGN KEY(feed_id) REFERENCES feeds(id)
+            )
+            """
+        )
+        conn.commit()
+
+
+def get_feed(url: str, db_path: str = DB_PATH) -> Optional[sqlite3.Row]:
+    """Retrieve a feed by URL."""
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute("SELECT * FROM feeds WHERE url = ?", (url,))
+        return cur.fetchone()
+
+
+def get_feed_by_id(feed_id: int, db_path: str = DB_PATH) -> Optional[sqlite3.Row]:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute("SELECT * FROM feeds WHERE id = ?", (feed_id,))
+        return cur.fetchone()
+
+
+def list_feeds(db_path: str = DB_PATH) -> List[sqlite3.Row]:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute("SELECT * FROM feeds ORDER BY title")
+        return cur.fetchall()
+
+
+def add_feed(url: str, title: str, db_path: str = DB_PATH) -> int:
+    """Insert or return an existing feed and return its id."""
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO feeds (url, title) VALUES (?, ?)", (url, title)
+        )
+        if cur.rowcount:
+            feed_id = cur.lastrowid
+        else:
+            cur = conn.execute("SELECT id FROM feeds WHERE url = ?", (url,))
+            feed_id = cur.fetchone()[0]
+        conn.commit()
+        return feed_id
+
+
+def get_episode(url: str, db_path: str = DB_PATH) -> Optional[sqlite3.Row]:
+    """Retrieve a processed episode by URL."""
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute("SELECT * FROM episodes WHERE url = ?", (url,))
+        return cur.fetchone()
+
+
+def save_episode(
+    url: str,
+    title: str,
+    transcript: str,
+    summary: str,
+    action_items: Iterable[str],
+    feed_id: int,
+    db_path: str = DB_PATH,
+) -> None:
+    """Save a processed episode to the DB."""
+    actions = "\n".join(action_items)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO episodes
+                (url, title, transcript, summary, action_items, feed_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (url, title, transcript, summary, actions, feed_id),
+        )
+        conn.commit()
+
+
+def list_episodes(feed_id: int, db_path: str = DB_PATH) -> List[sqlite3.Row]:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.execute(
+            "SELECT * FROM episodes WHERE feed_id = ? ORDER BY id", (feed_id,)
+        )
+        return cur.fetchall()

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>PodInsights</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        h1 { color: #333; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+        .processed { color: green; }
+    </style>
+</head>
+<body>
+    <h1>{{ feed.title }}</h1>
+    <p><a href="{{ url_for('index') }}">Back to feeds</a></p>
+
+    {% if episodes %}
+    <h2>Episodes</h2>
+    <table>
+        <tr><th>Title</th><th>Transcribed</th><th>Summarized</th><th>Actions</th><th>Process</th></tr>
+        {% for ep in episodes %}
+        <tr>
+            <td>{{ ep.title }}</td>
+            <td>{% if ep.status.transcribed %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
+            <td>{% if ep.status.summarized %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
+            <td>{% if ep.status.actions %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
+            <td><a href="{{ url_for('process_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id) }}">Process</a></td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+</body>
+</html>

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>PodInsights Feeds</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        h1 { color: #333; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+    </style>
+</head>
+<body>
+    <h1>Stored Podcast Feeds</h1>
+    <form method="post">
+        <label for="feed_url">Add Feed URL:</label>
+        <input type="text" name="feed_url" id="feed_url" size="60">
+        <input type="submit" value="Add">
+    </form>
+    {% if feeds %}
+    <h2>Feeds</h2>
+    <table>
+        <tr><th>Title</th><th>URL</th><th>View</th></tr>
+        {% for f in feeds %}
+        <tr>
+            <td>{{ f.title }}</td>
+            <td>{{ f.url }}</td>
+            <td><a href="{{ url_for('view_feed', feed_id=f.id) }}">Open</a></td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        h1 { color: #333; }
+    </style>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <h2>Summary</h2>
+    <pre>{{ summary }}</pre>
+    <h2>Action Items</h2>
+    <ul>
+    {% for item in actions %}
+        <li>{{ item }}</li>
+    {% endfor %}
+    </ul>
+    {% if feed_id %}
+    <p><a href="{{ url_for('view_feed', feed_id=feed_id) }}">Back to feed</a></p>
+    {% else %}
+    <p><a href="{{ url_for('index') }}">Home</a></p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- store podcast feeds in a new table and link episodes to feeds
- show all stored feeds on the home page
- display per-episode processing status for each feed
- add back-links between pages
- document the new feed-browsing capability

## Testing
- `python -m py_compile $(git ls-files '*.py')`
