### PR TITLE
Add JIRA ticket tracking UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ JIRA Cloud instance:
 - `JIRA_PROJECT_KEY` – project key for new issues
 
 Select the action items you want to track and click **Create JIRA Tickets**.
+Created issues are stored locally so you can access them later. When viewing an
+episode's results the associated JIRA tickets are listed with links. A dedicated
+"Tickets" page in the web interface lists every issue that has been created.

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,8 @@
     <header>
         <h1>{% block header %}PodInsights{% endblock %}</h1>
         <nav>
-            <a href="{{ url_for('index') }}">Feeds</a>
+            <a href="{{ url_for('index') }}">Feeds</a> |
+            <a href="{{ url_for('view_tickets') }}">Tickets</a>
         </nav>
     </header>
     <main>

--- a/templates/jira_result.html
+++ b/templates/jira_result.html
@@ -5,7 +5,11 @@
 <p>Created {{ created|length }} tickets:</p>
 <ul>
 {% for item in created %}
-  <li>{{ item }}</li>
+  {% if item.error %}
+  <li>{{ item.error }}</li>
+  {% else %}
+  <li><a href="{{ item.url }}" target="_blank">{{ item.key }}</a></li>
+  {% endif %}
 {% endfor %}
 </ul>
 <p><a href="{{ url_for('index') }}">Home</a></p>

--- a/templates/result.html
+++ b/templates/result.html
@@ -11,6 +11,7 @@
         <h2>Action Items</h2>
         <form method="post" action="{{ url_for('create_jira') }}">
             <input type="hidden" name="title" value="{{ title }}">
+            <input type="hidden" name="episode_url" value="{{ url }}">
             <ul>
             {% for item in actions %}
                 <li>
@@ -23,6 +24,14 @@
             </ul>
             <input type="submit" value="Create JIRA Tickets">
         </form>
+        {% if tickets %}
+        <h3>JIRA Tickets</h3>
+        <ul>
+        {% for t in tickets %}
+            <li><a href="{{ t.ticket_url }}" target="_blank">{{ t.ticket_key }}</a> - {{ t.action_item }}</li>
+        {% endfor %}
+        </ul>
+        {% endif %}
     </div>
 </div>
 {% if feed_id %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}JIRA Tickets{% endblock %}
+{% block header %}JIRA Tickets{% endblock %}
+{% block content %}
+{% if tickets %}
+<table>
+    <tr><th>Episode</th><th>Action Item</th><th>Ticket</th></tr>
+    {% for t in tickets %}
+    <tr>
+        <td>{{ t.episode_title }}</td>
+        <td>{{ t.action_item }}</td>
+        <td><a href="{{ t.ticket_url }}" target="_blank">{{ t.ticket_key }}</a></td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>No tickets found.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- store created JIRA issues in a new `jira_tickets` table
- list JIRA tickets for an episode and show links
- add a dedicated page that lists all tickets
- update navigation and docs

## Testing
- `python -m py_compile database.py podinsights.py podinsights_web.py`
- `pytest -q` *(fails: command not found)*