### PR TITLE
Add episode audio playback in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Navigate to `http://localhost:5000` and add an RSS feed URL. Stored feeds are li
 
 Episode descriptions and any images provided by the feed are displayed next to each title to help you identify episodes before processing.
 
+You can listen to any episode directly from the browser. Each episode row now includes a small audio player so you can preview the content before processing or reviewing tickets.
+
 Processed episodes are stored in a local SQLite database (`episodes.db`). Each episode records the transcript, summary, and action items. The feed view reports whether these pieces of information have been extracted.
 
 

--- a/database.py
+++ b/database.py
@@ -151,10 +151,14 @@ def list_tickets(
     """List all JIRA tickets or those for a specific episode."""
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
+        columns = (
+            "jt.*, e.title AS episode_title, e.summary AS episode_summary,"
+            " e.url AS episode_url, e.feed_id AS feed_id"
+        )
         if episode_id is None:
             cur = conn.execute(
-                """
-                SELECT jt.*, e.title AS episode_title
+                f"""
+                SELECT {columns}
                 FROM jira_tickets jt
                 JOIN episodes e ON jt.episode_id = e.id
                 ORDER BY jt.id
@@ -162,8 +166,8 @@ def list_tickets(
             )
         else:
             cur = conn.execute(
-                """
-                SELECT jt.*, e.title AS episode_title
+                f"""
+                SELECT {columns}
                 FROM jira_tickets jt
                 JOIN episodes e ON jt.episode_id = e.id
                 WHERE jt.episode_id = ?

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -10,6 +10,7 @@
         <th>Title</th>
         <th>Description</th>
         <th>Image</th>
+        <th>Play</th>
         <th>Transcribed</th>
         <th>Summarized</th>
         <th>Actions</th>
@@ -20,6 +21,11 @@
         <td>{{ ep.title }}</td>
         <td>{{ ep.description }}</td>
         <td>{% if ep.image %}<img src="{{ ep.image }}" alt="image" width="100">{% endif %}</td>
+        <td>
+            <audio controls preload="none" src="{{ ep.enclosure }}">
+                Your browser does not support the audio element.
+            </audio>
+        </td>
         <td>{% if ep.status.transcribed %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
         <td>{% if ep.status.summarized %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
         <td>{% if ep.status.actions %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>

--- a/templates/result.html
+++ b/templates/result.html
@@ -2,6 +2,9 @@
 {% block title %}{{ title }}{% endblock %}
 {% block header %}{{ title }}{% endblock %}
 {% block content %}
+<audio controls src="{{ url }}" style="width: 100%; margin-bottom: 1em;">
+    Your browser does not support the audio element.
+</audio>
 <div class="tile-container">
     <div class="tile">
         <h2>Summary</h2>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -4,10 +4,26 @@
 {% block content %}
 {% if tickets %}
 <table>
-    <tr><th>Episode</th><th>Action Item</th><th>Ticket</th></tr>
+    <tr>
+        <th>Episode</th>
+        <th>Play</th>
+        <th>Summary</th>
+        <th>Action Item</th>
+        <th>Ticket</th>
+    </tr>
     {% for t in tickets %}
     <tr>
-        <td>{{ t.episode_title }}</td>
+        <td>
+            <a href="{{ url_for('process_episode', url=t.episode_url, title=t.episode_title, feed_id=t.feed_id) }}">
+                {{ t.episode_title }}
+            </a>
+        </td>
+        <td>
+            <audio controls preload="none" src="{{ t.episode_url }}">
+                Your browser does not support the audio element.
+            </audio>
+        </td>
+        <td>{{ t.episode_summary|truncate(200) }}</td>
         <td>{{ t.action_item }}</td>
         <td><a href="{{ t.ticket_url }}" target="_blank">{{ t.ticket_key }}</a></td>
     </tr>


### PR DESCRIPTION
## Summary
- add audio player to feed listing page
- allow playing episodes on ticket listings
- embed player on episode results page
- update README to document new playback feature

## Testing
- `python -m py_compile database.py podinsights_web.py podinsights.py`
- `pytest -q` *(fails: command not found)*