### PR TITLE
Improve feed episode descriptions

### DIFF
--- a/podinsights_web.py
+++ b/podinsights_web.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import os
 import tempfile
 from flask import Flask, request, render_template, redirect, url_for
+import re
 import feedparser
 import requests
 from database import (
@@ -25,6 +26,18 @@ from podinsights import (
 app = Flask(__name__)
 configure_logging()
 init_db()
+
+
+def make_short_description(text: str, limit: int = 200) -> str:
+    """Return a short preview from the provided text."""
+    if not text:
+        return ""
+    text = text.strip()
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    short = " ".join(sentences[:2])
+    if len(short) > limit:
+        short = short[:limit].rstrip() + "..."
+    return short
 
 def create_jira_issue(summary: str, description: str) -> dict:
     """Create a JIRA issue using credentials from environment variables."""
@@ -106,6 +119,7 @@ def view_feed(feed_id: int):
         episodes.append({
             'title': entry.title,
             'description': desc,
+            'short_description': make_short_description(desc),
             'image': img,
             'enclosure': url,
             'status': status,

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,10 @@
             background: rgba(255, 255, 255, 0.7);
             z-index: 1000;
         }
+        .description-cell {
+            white-space: normal;
+            max-width: 400px;
+        }
     </style>
 </head>
 <body>

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -19,7 +19,11 @@
     {% for ep in episodes %}
     <tr>
         <td>{{ ep.title }}</td>
-        <td>{{ ep.description }}</td>
+        <td class="description-cell">
+            <span class="desc-short">{{ ep.short_description }}</span>
+            <span class="desc-full d-none">{{ ep.description }}</span>
+            <button class="btn btn-link p-0 desc-toggle">See more</button>
+        </td>
         <td>{% if ep.image %}<img src="{{ ep.image }}" alt="image" width="100">{% endif %}</td>
         <td>
             <audio controls preload="none" src="{{ ep.enclosure }}">
@@ -37,6 +41,19 @@
         </td>
     </tr>
     {% endfor %}
-</table>
-{% endif %}
+  </table>
+  {% endif %}
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.desc-toggle').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var shortEl = btn.parentElement.querySelector('.desc-short');
+            var fullEl = btn.parentElement.querySelector('.desc-full');
+            shortEl.classList.toggle('d-none');
+            fullEl.classList.toggle('d-none');
+            btn.textContent = btn.textContent.trim() === 'See more' ? 'See less' : 'See more';
+        });
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a short description in episode list and include full text
- allow toggling full episode descriptions with JS
- keep episode description column tidy with simple CSS

## Testing
- `python -m py_compile podinsights_web.py`
- `python -m py_compile database.py podinsights.py`