### PR TITLE
Add episode description to detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ python podinsights_web.py
 
 Navigate to `http://localhost:5001` and add an RSS feed URL. Stored feeds are listed on the home page so you can return to them later. Selecting a feed shows the episodes along with their processing status.
 When you process an episode a small overlay indicates progress until the results are displayed.
+The episode description is shown at the top of the results page so you have context when reviewing the summary and action items.
 
 Episode descriptions and any images provided by the feed are displayed next to each title to help you identify episodes before processing.
 

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -35,7 +35,7 @@
         <td>{% if ep.status.actions %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
         <td>
             <a
-                href="{{ url_for('process_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id) }}"
+                href="{{ url_for('process_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id, description=ep.clean_description) }}"
                 data-processing="true"
             >Process</a>
         </td>

--- a/templates/result.html
+++ b/templates/result.html
@@ -5,6 +5,9 @@
 <audio controls src="{{ url }}" class="w-100 mb-3">
     Your browser does not support the audio element.
 </audio>
+{% if description %}
+<p class="mb-4">{{ description }}</p>
+{% endif %}
 <div class="row gy-4">
     <div class="col-md-6">
         <h2>Summary</h2>


### PR DESCRIPTION
## Summary
- display a cleaned episode description at the top of the results page
- forward description to the process route from feed listings
- retrieve description from the feed if not provided
- document the new feature in README

## Testing
- `python -m py_compile *.py`