### PR TITLE
Add episode status page with queue processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Created issues are stored locally so you can access them later. When viewing an
 episode's results the associated JIRA tickets are listed with links. A dedicated
 "Tickets" page in the web interface lists every issue that has been created.
 
+The web interface also provides a **Status** page listing all queued and processed episodes from every feed. Use the **Queue** link next to an episode to process it in the background and track its progress on the Status page.
+
 ## Credits
 
 Developed by Sedric "Show Up Show Out" Louissaint from Show Up Show Out Security. 

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,6 +54,7 @@
             <a class="navbar-brand" href="{{ url_for('index') }}">PodInsights</a>
             <div class="navbar-nav">
                 <a class="nav-link" href="{{ url_for('index') }}">Feeds</a>
+                <a class="nav-link" href="{{ url_for('status_page') }}">Status</a>
                 <a class="nav-link" href="{{ url_for('view_tickets') }}">Tickets</a>
             </div>
         </div>

--- a/templates/feed.html
+++ b/templates/feed.html
@@ -14,7 +14,9 @@
         <th>Transcribed</th>
         <th>Summarized</th>
         <th>Actions</th>
+        <th>Status</th>
         <th>Process</th>
+        <th>Queue</th>
     </tr>
     {% for ep in episodes %}
     <tr>
@@ -33,11 +35,15 @@
         <td>{% if ep.status.transcribed %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
         <td>{% if ep.status.summarized %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
         <td>{% if ep.status.actions %}<span class="processed">Yes</span>{% else %}No{% endif %}</td>
+        <td>{{ ep.status.state }}</td>
         <td>
             <a
                 href="{{ url_for('process_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id, description=ep.clean_description) }}"
                 data-processing="true"
             >Process</a>
+        </td>
+        <td>
+            <a href="{{ url_for('enqueue_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id) }}">Queue</a>
         </td>
     </tr>
     {% endfor %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block title %}Processing Status{% endblock %}
+{% block header %}Processing Status{% endblock %}
+{% block content %}
+{% if episodes %}
+<table class="table table-striped">
+    <tr>
+        <th>Feed</th>
+        <th>Title</th>
+        <th>Status</th>
+        <th>Play</th>
+        <th>View</th>
+    </tr>
+    {% for ep in episodes %}
+    <tr>
+        <td>{{ feeds.get(ep.feed_id, ep.feed_id) }}</td>
+        <td>{{ ep.title }}</td>
+        <td>{{ ep.status or 'queued' }}</td>
+        <td>
+            <audio controls preload="none" src="{{ ep.url }}">
+                Your browser does not support the audio element.
+            </audio>
+        </td>
+        <td>
+        {% if ep.status == 'complete' %}
+            <a href="{{ url_for('process_episode', url=ep.url, title=ep.title, feed_id=ep.feed_id) }}">View</a>
+        {% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% else %}
+<p>No episodes queued or processed.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- support storing episode processing status in SQLite
- add a background worker queue
- allow queuing episodes from the feed view
- list all queued and completed episodes on new Status page
- link Status page from navigation

## Testing
- `python -m py_compile database.py podinsights_web.py`
