### PR TITLE
Add Jira status display

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Each created ticket includes context about where the action item came from. The
 description notes the podcast episode title and includes the generated summary
 so your team has immediate background when reviewing the issue.
 
+Ticket status is fetched directly from JIRA whenever you view the tickets page
+or the list of tickets on an episode's results page, so you can quickly see
+whether items are still open or have been resolved.
+
 The web interface also provides a **Status** page listing all queued and processed episodes from every feed. Use the **Queue** link next to an episode to process it in the background and track its progress on the Status page.
 
 ## Credits

--- a/templates/result.html
+++ b/templates/result.html
@@ -34,7 +34,7 @@
         <h3>JIRA Tickets</h3>
         <ul>
         {% for t in tickets %}
-            <li><a href="{{ t.ticket_url }}" target="_blank">{{ t.ticket_key }}</a> - {{ t.action_item }}</li>
+            <li><a href="{{ t.ticket_url }}" target="_blank">{{ t.ticket_key }}</a> ({{ t.status }}) - {{ t.action_item }}</li>
         {% endfor %}
         </ul>
         {% endif %}

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -10,6 +10,7 @@
         <th>Summary</th>
         <th>Action Item</th>
         <th>Ticket</th>
+        <th>Status</th>
     </tr>
     {% for t in tickets %}
     <tr>
@@ -26,6 +27,7 @@
         <td>{{ t.episode_summary|truncate(200) }}</td>
         <td>{{ t.action_item }}</td>
         <td><a href="{{ t.ticket_url }}" target="_blank">{{ t.ticket_key }}</a></td>
+        <td>{{ t.status }}</td>
     </tr>
     {% endfor %}
 </table>


### PR DESCRIPTION
## Summary
- show current Jira status for tickets on the tickets page
- show Jira status below action items in episode results
- document Jira status display feature

## Testing
- `python -m py_compile podinsights_web.py database.py podinsights.py`