### PR TITLE
Add episode sorting

### DIFF
--- a/templates/feed.html
+++ b/templates/feed.html
@@ -38,12 +38,12 @@
         <td>{{ ep.status.state }}</td>
         <td>
             <a
-                href="{{ url_for('process_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id, description=ep.clean_description) }}"
+                href="{{ url_for('process_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id, description=ep.clean_description, published=ep.published) }}"
                 data-processing="true"
             >Process</a>
         </td>
         <td>
-            <a href="{{ url_for('enqueue_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id) }}">Queue</a>
+            <a href="{{ url_for('enqueue_episode', url=ep.enclosure, title=ep.title, feed_id=feed.id, published=ep.published) }}">Queue</a>
         </td>
     </tr>
     {% endfor %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -3,10 +3,17 @@
 {% block header %}Processing Status{% endblock %}
 {% block content %}
 {% if episodes %}
+<p>
+    Sort by:
+    <a href="{{ url_for('status_page', sort='released') }}">Release date</a> |
+    <a href="{{ url_for('status_page', sort='processed') }}">Processed date</a>
+</p>
 <table class="table table-striped">
     <tr>
         <th>Feed</th>
         <th>Title</th>
+        <th>Released</th>
+        <th>Processed</th>
         <th>Status</th>
         <th>Play</th>
         <th>View</th>
@@ -15,6 +22,8 @@
     <tr>
         <td>{{ feeds.get(ep.feed_id, ep.feed_id) }}</td>
         <td>{{ ep.title }}</td>
+        <td>{{ ep.published or 'N/A' }}</td>
+        <td>{{ ep.processed_at or 'N/A' }}</td>
         <td>{{ ep.status or 'queued' }}</td>
         <td>
             <audio controls preload="none" src="{{ ep.url }}">
@@ -23,7 +32,7 @@
         </td>
         <td>
         {% if ep.status == 'complete' %}
-            <a href="{{ url_for('process_episode', url=ep.url, title=ep.title, feed_id=ep.feed_id) }}">View</a>
+            <a href="{{ url_for('process_episode', url=ep.url, title=ep.title, feed_id=ep.feed_id, published=ep.published) }}">View</a>
         {% endif %}
         </td>
     </tr>

--- a/templates/tickets.html
+++ b/templates/tickets.html
@@ -15,7 +15,7 @@
     {% for t in tickets %}
     <tr>
         <td>
-            <a href="{{ url_for('process_episode', url=t.episode_url, title=t.episode_title, feed_id=t.feed_id) }}">
+            <a href="{{ url_for('process_episode', url=t.episode_url, title=t.episode_title, feed_id=t.feed_id, published=t.published) }}">
                 {{ t.episode_title }}
             </a>
         </td>


### PR DESCRIPTION
## Summary
- add `published` and `processed_at` fields to episodes table
- include episode timestamps when queuing and saving
- allow sorting on the status page by release or processed date
- show release & processed dates in the status table

## Testing
- `python -m py_compile database.py podinsights_web.py`